### PR TITLE
Invoke channel disconnected callbacks when disconnecting from the cable

### DIFF
--- a/lib/action_cable.dart
+++ b/lib/action_cable.dart
@@ -46,6 +46,11 @@ class ActionCable {
     _timer.cancel();
     _socketChannel.sink.close();
     _listener.cancel();
+    _onChannelDisconnectedCallbacks.values
+      .where((onDisconnected) => onDisconnected != null)
+      .forEach((onDisconnected) {
+        onDisconnected!();
+      });
   }
 
   // check if there is no ping for 3 seconds and signal a [onConnectionLost] if


### PR DESCRIPTION
I was surprised that this isn't the default behavior, but I think it makes sense that you would want to call these when purposefully calling the ActionCable disconnect method.