### PR TITLE
Handle disconnect message when ActionCable server rejects the connection.

### DIFF
--- a/lib/action_cable.dart
+++ b/lib/action_cable.dart
@@ -116,7 +116,7 @@ class ActionCable {
       case 'ping':
         // rails sends epoch as seconds not miliseconds
         _lastPing =
-            DateTime.fromMillisecondsSinceEpoch(payload['message'] * 1000);
+            DateTime.now();
         break;
       case 'welcome':
         if (onConnected != null) {
@@ -124,10 +124,18 @@ class ActionCable {
         }
         break;
       case 'disconnect':
-        final channelId = parseChannelId(payload['identifier']);
-        final onDisconnected = _onChannelDisconnectedCallbacks[channelId];
-        if (onDisconnected != null) {
-          onDisconnected();
+        final identifier = payload['identifier'];
+        if (identifier != null) {
+          final channelId = parseChannelId(payload['identifier']);
+          final onDisconnected = _onChannelDisconnectedCallbacks[channelId];
+          if (onDisconnected != null) {
+            onDisconnected();
+          }
+        } else {
+          final reason = payload['reason'];
+          if (reason != null && reason == 'unauthorized') {
+            if (this.onCannotConnect != null) this.onCannotConnect!();
+          }
         }
         break;
       case 'confirm_subscription':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: action_cable
-version: 1.2.0
+version: 1.2.1
 description: >-
   ActionCable client port in dart, available in web, dartVM and flutter.
 homepage: https://github.com/namiwang/actioncable_dart


### PR DESCRIPTION
This pull request properly handles disconnect when action cable server rejects the connection. It also uses local time for ping instead of server time since they can be out of sync.