### PR TITLE
Fix argument type in onMessage function causing bug.

### DIFF
--- a/lib/action_cable.dart
+++ b/lib/action_cable.dart
@@ -149,7 +149,7 @@ class ActionCable {
     final channelId = parseChannelId(payload['identifier']);
     final onMessage = _onChannelMessageCallbacks[channelId];
     if (onMessage != null) {
-      onMessage(payload['message']);
+      onMessage(payload);
     }
   }
 


### PR DESCRIPTION
original typdef expecting Map datastructure but can be string.